### PR TITLE
Sheerid griddle table resize fix

### DIFF
--- a/build/Griddle.js
+++ b/build/Griddle.js
@@ -7816,6 +7816,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	            "parentRowCollapsedComponent": "▶",
 	            "parentRowExpandedComponent": "▼",
 	            "onRowClick": null,
+	            "onRowDoubleClick": null,
 	            "multipleSelectionSettings": null
 	        };
 	    },

--- a/modules/gridRow.jsx.js
+++ b/modules/gridRow.jsx.js
@@ -1,7 +1,7 @@
 /*
    See License / Disclaimer https://raw.githubusercontent.com/DynamicTyped/Griddle/master/LICENSE
    ** modified by coatsbj to support double-click **
-*/
+ */
 'use strict';
 
 var React = require('react');

--- a/modules/gridRow.jsx.js
+++ b/modules/gridRow.jsx.js
@@ -35,6 +35,7 @@ var GridRow = React.createClass({
             "parentRowCollapsedComponent": "▶",
             "parentRowExpandedComponent": "▼",
             "onRowClick": null,
+            "onRowDoubleClick": null,
             "multipleSelectionSettings": null
         };
     },

--- a/modules/gridRowContainer.jsx.js
+++ b/modules/gridRowContainer.jsx.js
@@ -1,7 +1,7 @@
 /*
    See License / Disclaimer https://raw.githubusercontent.com/DynamicTyped/Griddle/master/LICENSE
    ** modified by coatsbj to support double-click **
-*/
+ */
 'use strict';
 
 var React = require('react');
@@ -25,6 +25,7 @@ var GridRowContainer = React.createClass({
       "parentRowCollapsedComponent": "▶",
       "parentRowExpandedComponent": "▼",
       "onRowClick": null,
+      "onRowDoubleClick": null,
       "multipleSelectionSettings": null
     };
   },

--- a/modules/griddle.jsx.js
+++ b/modules/griddle.jsx.js
@@ -4,8 +4,8 @@
    Copyright (c) 2014 Ryan Lanciaux | DynamicTyped
 
    See License / Disclaimer https://raw.githubusercontent.com/DynamicTyped/Griddle/master/LICENSE
- ** modified by coatsbj to support double-click **
-*/
+   ** modified by coatsbj to support double-click AND to support a fix for grid resizing issues when in virtual scrolling mode **
+ */
 'use strict';
 
 var _extends = Object.assign || function (target) {
@@ -132,6 +132,7 @@ var Griddle = React.createClass({
             "enableSort": true,
             "onRowClick": null,
             "onRowDoubleClick": null,
+            "applyGridResizeFix": false,
             /* css class names */
             "sortAscendingClassName": "sort-ascending",
             "sortDescendingClassName": "sort-descending",
@@ -854,7 +855,8 @@ var Griddle = React.createClass({
             externalIsLoading: this.props.externalIsLoading,
             hasMorePages: hasMorePages,
             onRowClick: this.props.onRowClick,
-            onRowDoubleClick: this.props.onRowDoubleClick}));
+            onRowDoubleClick: this.props.onRowDoubleClick,
+            applyGridResizeFix: this.props.applyGridResizeFix }));
     },
     getContentSection: function getContentSection(data, cols, meta, pagingContent, hasMorePages, globalData) {
         if (this.shouldUseCustomGridComponent() && this.props.customGridComponent !== null) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sheerid/griddle-react",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Griddle - A fast and flexible grid component for React.  Forked and enhanced by SheerID for internal use only.",
   "keywords": [
     "react-component",

--- a/scripts/gridRow.jsx
+++ b/scripts/gridRow.jsx
@@ -1,6 +1,7 @@
 /*
    See License / Disclaimer https://raw.githubusercontent.com/DynamicTyped/Griddle/master/LICENSE
-*/
+   ** modified by coatsbj to support double-click **
+ */
 var React = require('react');
 var ColumnProperties = require('./columnProperties.js');
 var deep = require('./deep.js');
@@ -38,6 +39,11 @@ var GridRow = React.createClass({
             this.props.onRowClick(this, e);
         }else if(this.props.hasChildren){
             this.props.toggleChildren();
+        }
+    },
+    handleDoubleClick: function handleDoubleClick(e) {
+        if (this.props.onRowDoubleClick !== null && isFunction(this.props.onRowDoubleClick)) {
+            this.props.onRowDoubleClick(this, e);
         }
     },
     handleSelectionChange: function(e) {
@@ -108,13 +114,13 @@ var GridRow = React.createClass({
             if (this.props.columnSettings.hasColumnMetadata() && typeof meta !== 'undefined' && meta !== null) {
               if (typeof meta.customComponent !== 'undefined' && meta.customComponent !== null) {
                 var customComponent = <meta.customComponent data={col[1]} rowData={dataView} metadata={meta} />;
-                returnValue = <td onClick={this.handleClick} className={meta.cssClassName} key={index} style={columnStyles}>{customComponent}</td>;
+                returnValue = <td onClick={this.handleClick} onDoubleClick={this.handleDoubleClick} className={meta.cssClassName} key={index} style={columnStyles}>{customComponent}</td>;
               } else {
-                returnValue = <td onClick={this.handleClick} className={meta.cssClassName} key={index} style={columnStyles}>{firstColAppend}{this.formatData(col[1])}</td>;
+                returnValue = <td onClick={this.handleClick} onDoubleClick={this.handleDoubleClick} className={meta.cssClassName} key={index} style={columnStyles}>{firstColAppend}{this.formatData(col[1])}</td>;
               }
             }
 
-            return returnValue || (<td onClick={this.handleClick} key={index} style={columnStyles}>{firstColAppend}{col[1]}</td>);
+            return returnValue || (<td onClick={this.handleClick} onDoubleClick={this.handleDoubleClick} key={index} style={columnStyles}>{firstColAppend}{col[1]}</td>);
         });
 
         // Don't compete with onRowClick, but if no onRowClick function then

--- a/scripts/gridRow.jsx
+++ b/scripts/gridRow.jsx
@@ -31,6 +31,7 @@ var GridRow = React.createClass({
         "parentRowCollapsedComponent": "▶",
         "parentRowExpandedComponent": "▼",
         "onRowClick": null,
+        "onRowDoubleClick": null,
 	    "multipleSelectionSettings": null
       }
     },

--- a/scripts/gridRowContainer.jsx
+++ b/scripts/gridRowContainer.jsx
@@ -1,6 +1,7 @@
 /*
    See License / Disclaimer https://raw.githubusercontent.com/DynamicTyped/Griddle/master/LICENSE
-*/
+   ** modified by coatsbj to support double-click **
+ */
 var React = require('react');
 var ColumnProperties = require('./columnProperties.js');
 var pick = require('lodash/pick');
@@ -20,7 +21,8 @@ var GridRowContainer = React.createClass({
         "parentRowCollapsedComponent": "▶",
         "parentRowExpandedComponent": "▼",
         "onRowClick": null,
-	    "multipleSelectionSettings": null
+        "onRowDoubleClick": null,
+        "multipleSelectionSettings": null
       };
     },
     getInitialState: function(){
@@ -74,6 +76,7 @@ var GridRowContainer = React.createClass({
           paddingHeight={that.props.paddingHeight}
           rowHeight={that.props.rowHeight}
           onRowClick={that.props.onRowClick}
+          onRowDoubleClick={that.props.onRowDoubleClick}
           multipleSelectionSettings={this.props.multipleSelectionSettings} />
       );
 

--- a/scripts/gridTable.jsx
+++ b/scripts/gridTable.jsx
@@ -1,6 +1,7 @@
 /*
    See License / Disclaimer https://raw.githubusercontent.com/DynamicTyped/Griddle/master/LICENSE
-*/
+ ** modified by coatsbj to support double-click AND to support a fix for grid resizing issues when in virtual scrolling mode **
+ */
 var React = require('react');
 var GridTitle = require('./gridTitle.jsx');
 var GridRowContainer = require('./gridRowContainer.jsx');
@@ -35,7 +36,9 @@ var GridTable = React.createClass({
       "parentRowExpandedComponent": "▼",
       "externalLoadingComponent": null,
       "externalIsLoading": false,
-      "onRowClick": null
+      "onRowClick": null,
+      "onRowDoubleClick": null,
+      "applyGridResizeFix": false
     }
   },
   getInitialState: function(){
@@ -52,6 +55,22 @@ var GridTable = React.createClass({
   componentDidUpdate: function(prevProps, prevState) {
     // After the subsequent renders, see if we need to load additional pages.
     this.gridScroll();
+  },
+  componentWillReceiveProps: function componentWillReceiveProps(nextProps) {
+      // [BJC, 5/31/2017] NOTE: The following is to ensure grid re-renders upon large-magnitude resize operation when grid was previously quite small in size
+      // [BJC, 5/31/2017] NOTE: Because changing state will force a re-render, we ONLY want to do it if it's ABSOLUTELY necessary
+      if (this.props.applyGridResizeFix
+          && this.props.enableInfiniteScroll
+          && nextProps.enableInfiniteScroll
+          && this.refs.scrollable
+          && nextProps.bodyHeight !== this.props.bodyHeight
+          && this.refs.scrollable.scrollHeight > this.refs.scrollable.clientHeight
+          && (nextProps.bodyHeight - this.state.clientHeight) > nextProps.rowHeight) {
+          this.setState({
+              clientHeight: nextProps.bodyHeight,
+              scrollHeight: (nextProps.bodyHeight > this.state.scrollHeight) ? nextProps.bodyHeight : this.state.scrollHeight
+          });
+      }
   },
   gridScroll: function(){
     if (this.props.enableInfiniteScroll && !this.props.externalIsLoading) {
@@ -75,7 +94,7 @@ var GridTable = React.createClass({
         this.setState(newState);
       }
 
-      // Determine the diff by subtracting the amount scrolled by the total height, taking into consideratoin
+      // Determine the diff by subtracting the amount scrolled by the total height, taking into consideration
       // the spacer's height.
       var scrollHeightDiff = scrollHeight - (scrollTop + clientHeight) - this.props.infiniteScrollLoadTreshold;
 
@@ -152,11 +171,12 @@ var GridTable = React.createClass({
                 columnSettings={that.props.columnSettings}
                 rowSettings={that.props.rowSettings}
                 paddingHeight={that.props.paddingHeight}
-		            multipleSelectionSettings={that.props.multipleSelectionSettings}
+                multipleSelectionSettings={that.props.multipleSelectionSettings}
                 rowHeight={that.props.rowHeight}
                 hasChildren={hasChildren}
                 tableClassName={that.props.className}
                 onRowClick={that.props.onRowClick}
+                onRowDoubleClick={that.props.onRowDoubleClick}
             />
           )
       });

--- a/scripts/griddle.jsx
+++ b/scripts/griddle.jsx
@@ -4,7 +4,8 @@
    Copyright (c) 2014 Ryan Lanciaux | DynamicTyped
 
    See License / Disclaimer https://raw.githubusercontent.com/DynamicTyped/Griddle/master/LICENSE
-*/
+   ** modified by coatsbj to support double-click AND to support a fix for grid resizing issues when in virtual scrolling mode **
+ */
 var React = require('react');
 var GridTable = require('./gridTable.jsx');
 var GridFilter = require('./gridFilter.jsx');
@@ -116,6 +117,8 @@ var Griddle = React.createClass({
             "isSubGriddle": false,
             "enableSort": true,
             "onRowClick": null,
+            "onRowDoubleClick": null,
+            "applyGridResizeFix": false,
             /* css class names */
             "sortAscendingClassName": "sort-ascending",
             "sortDescendingClassName": "sort-descending",
@@ -732,7 +735,7 @@ var Griddle = React.createClass({
 			getIsSelectAllChecked: this._getIsSelectAllChecked,
 			toggleSelectRow: this._toggleSelectRow,
 			getSelectedRowIds: this.getSelectedRowIds,
-      getIsRowChecked: this._getIsRowChecked
+            getIsRowChecked: this._getIsRowChecked
 		}
 	},
     isInfiniteScrollEnabled: function(){
@@ -877,7 +880,9 @@ var Griddle = React.createClass({
                 externalLoadingComponent={this.props.externalLoadingComponent}
                 externalIsLoading={this.props.externalIsLoading}
                 hasMorePages={hasMorePages}
-                onRowClick={this.props.onRowClick}/></div>)
+                onRowClick={this.props.onRowClick}
+                onRowDoubleClick={this.props.onRowDoubleClick}
+                applyGridResizeFix={this.props.applyGridResizeFix}/></div>)
     },
     getContentSection: function(data, cols, meta, pagingContent, hasMorePages, globalData){
         if(this.shouldUseCustomGridComponent() && this.props.customGridComponent !== null){


### PR DESCRIPTION
*** NOTE: THE COMMIT INCLUDES THE ACTUAL COMPILED OUTPUT, AS IT WAS ALREADY BEING INCLUDED. THIS MAY CHANGE IN THE FUTURE. YOU ONLY NEED TO FOCUS ON THE *.jsx FILES, NOT ANY *.js OR *.jsx.js FILES! **

** 0.1.4 update contains: **
- A fix for resizing (massive expansion) grid in virtualized mode, to ensure displayed rows update in this case
- Previously, double-click functionality was addressed through /modules files. Couldn't figure out why this stuff kept getting overwritten. Finally took a look and saw that these .jsx.js files were created via a babel process in the grunt file, and the source for those quasi-compiled files were the /scripts/.jsx files. Applied previous changes to the .jsx files to ensure work wouldn't be overwritten in future builds
- Incremented the version number

A subsequent fix is pending for performance on scroll of certain records...need to throttle re-rendering for virtualized rows with wrapped content. However, this fix has some quirks, so keeping it out of 0.1.4 unless a defect is logged for it, will put in a separate 0.1.5 branch.